### PR TITLE
feat: Groq provider — owner-only key, models, gated Whisper transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,19 @@ CEREBRAS_API_KEY=
 OPENROUTER_API_KEY=
 GOOGLE_API_KEY=
 
+# --- Groq (owner-only key) ---
+# Powers fast Groq chat/translation models AND voice-to-text (Whisper).
+# OWNER-ONLY: sits behind the owner login gate below, so anonymous and free-tier
+# visitors can never spend it (for chat/translation or transcription). Other users
+# bring their own Groq key via Settings. Get one at https://console.groq.com/keys
+# The 🎙️ audio button and Groq models only appear when Groq is available (owner key
+# here, or a visitor's own Groq key). FREE_PROVIDER can NOT be set to groq.
+GROQ_API_KEY=
+# Groq OpenAI-compatible endpoint (rarely needs changing).
+GROQ_BASE_URL=https://api.groq.com/openai/v1
+# Whisper STT model: whisper-large-v3-turbo (default, fast/cheap) or whisper-large-v3 (accurate).
+GROQ_STT_MODEL=whisper-large-v3-turbo
+
 # --- Free tier (shared, server-funded) ---
 # Let anonymous visitors use ONE server-funded model for free, without a key and without
 # logging in. Requires the FREE_PROVIDER key above to be set. Every visitor is rate limited,

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Get a free key from any of these providers:
 | **Cerebras** | [cloud.cerebras.ai](https://cloud.cerebras.ai) | Very fast inference |
 | **OpenRouter** | [openrouter.ai/keys](https://openrouter.ai/keys) | Free models are auto-selected for you |
 | **Google AI Studio** | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | Gemma & Gemini; required for Live voice |
+| **Groq** | [console.groq.com/keys](https://console.groq.com/keys) | Very fast; also powers voice-to-text (Whisper). Bring your own key to use it |
 
 Steps: pick a provider → paste the key → **Save key** → **Test** → **Use**.
 
@@ -101,11 +102,15 @@ Copy `.env.example` to `.env` and fill in what you need. Keys added in the UI ta
 HOST=0.0.0.0
 PORT=8080
 MAX_TEXT_LENGTH=8000
-DEFAULT_PROVIDER=cerebras
+DEFAULT_PROVIDER=cerebras   # groq is also valid (DEFAULT_PROVIDER=groq)
 
 CEREBRAS_API_KEY=
 OPENROUTER_API_KEY=
 GOOGLE_API_KEY=
+
+GROQ_API_KEY=                                     # owner-only; also powers voice-to-text
+GROQ_BASE_URL=https://api.groq.com/openai/v1     # OpenAI-compatible endpoint
+GROQ_STT_MODEL=whisper-large-v3-turbo            # or whisper-large-v3
 
 OWNER_USERNAME=
 OWNER_PASSWORD=
@@ -127,6 +132,27 @@ The **Live** tab does real-time speech-to-speech translation using Google's Live
 - Needs a **Google AI Studio** key: your own (from **Your API Key**) or, if you're the logged-in owner, the server's Google key.
 - The microphone only works on a **secure origin**: `localhost` or an `https://` URL. Over plain `http://` on a public IP, browsers block mic access.
 - Audio streams to the server, which proxies to Google, so the key stays server-side when using the owner key.
+
+## Groq (fast chat, translation & voice-to-text)
+
+Groq adds very fast translation/chat models and powers the 🎙️ audio transcription (voice-to-text) feature via Whisper.
+
+**Owner key vs. bring-your-own.** The server's `GROQ_API_KEY` in `.env` is owner-only — it sits behind the same owner login gate as your other configured keys, so anonymous and free-tier visitors can never spend it (neither for chat/translation nor for Whisper transcription). Everyone else brings their own Groq key from ⚙ **Settings → Your API Key** (pick **Groq**, **Save** → **Test** → **Use**). Get a free key at [console.groq.com/keys](https://console.groq.com/keys). Note: owner-only enforcement requires `OWNER_USERNAME` / `OWNER_PASSWORD` to be set; on a deploy with the gate disabled every visitor counts as the owner (single-user/trusted mode).
+
+**When audio & Groq turn on.** The Groq models and the 🎙️ audio button appear only when Groq is available to you — you're the logged-in owner with `GROQ_API_KEY` set, or you've added your own Groq key in Settings. Otherwise the audio button stays hidden and Groq isn't offered.
+
+**Chat & translation models:**
+
+| Model | Notes |
+| --- | --- |
+| `llama-3.3-70b-versatile` | Meta, strong general-purpose (default), 131k ctx |
+| `llama-3.1-8b-instant` | Meta, fastest, 131k ctx |
+| `meta-llama/llama-4-scout-17b-16e-instruct` | Meta, multimodal (vision), 131k ctx |
+| `qwen/qwen3-32b` | Alibaba, strong multilingual |
+| `openai/gpt-oss-120b` | OpenAI open-weight, 131k ctx |
+| `openai/gpt-oss-20b` | OpenAI open-weight, smaller/faster |
+
+**Voice-to-text (Whisper):** `whisper-large-v3-turbo` (default, fast/cheap) or `whisper-large-v3` (highest accuracy). Tune with the `GROQ_STT_MODEL` / `GROQ_BASE_URL` knobs in the env block above.
 
 ## Security
 
@@ -173,6 +199,7 @@ Licensed under the [Apache License 2.0](LICENSE).
 - **Cerebras** — از [cloud.cerebras.ai](https://cloud.cerebras.ai) (بسیار سریع)
 - **OpenRouter** — از [openrouter.ai/keys](https://openrouter.ai/keys) (مدل‌های رایگان به‌صورت خودکار انتخاب می‌شوند)
 - **Google AI Studio** — از [aistudio.google.com/apikey](https://aistudio.google.com/apikey) (برای ترجمه‌ی زنده‌ی صدا لازم است)
+- **Groq** — از [console.groq.com/keys](https://console.groq.com/keys) (بسیار سریع؛ همچنین قابلیت تبدیل صدا به متن با Whisper را فراهم می‌کند؛ با کلید خودتان قابل استفاده است)
 
 مراحل: انتخاب سرویس ← وارد کردن کلید ← **ذخیره کلید** ← **تست** ← **استفاده**.
 
@@ -238,6 +265,7 @@ FREE_MAX_INPUT_CHARS=16000
 
 - فایل‌های `.env` و `data/` در گیت نادیده گرفته می‌شوند — هیچ کلیدی هرگز کامیت نمی‌شود.
 - کلید BYOK فقط در مرورگر بازدیدکننده می‌ماند و روی سرور ذخیره نمی‌شود.
+- کلید `GROQ_API_KEY` روی سرور فقط برای مالکِ لاگین‌کرده است؛ بازدیدکننده‌های رایگان هرگز از آن استفاده نمی‌کنند و باید کلید Groq خودشان را در تنظیمات وارد کنند. دکمه‌ی صدا فقط وقتی ظاهر می‌شود که Groq در دسترس شما باشد.
 - قبل از انتشار عمومی، حتماً `OWNER_USERNAME` و `OWNER_PASSWORD` را تنظیم کنید.
 
 ## مجوز

--- a/src/client/assets/js/app.js
+++ b/src/client/assets/js/app.js
@@ -32,7 +32,7 @@ import { initLangPicker } from "./langpicker.js";
 import { initChat, onLanguageChange, refreshChatConfig, refreshChatAccess } from "./chat-app.js";
 import { initSettings, refreshOwnerSection } from "./settings.js";
 import { initByokUi, refreshByokUi } from "./byok-ui.js";
-import { getRuntime, getRequestPayload, updateModel } from "./byok.js";
+import { getRuntime, getRequestPayload, updateModel, getGroqKey } from "./byok.js";
 import { initLive, stopLive, setLiveAvailable, refreshLiveAvailability, applyLiveTranslations } from "./live.js";
 import { initViewportSizing } from "./viewport.js";
 
@@ -241,11 +241,12 @@ const handleAudioFile = async (file) => {
 
   try {
     const dataUri = await readFileAsDataURL(file);
-    // Transcription uses the server-side Groq key (owner/free tier); do NOT forward the chat
-    // BYOK key here — it belongs to a different provider and Groq would reject it. Upload
-    // progress is surfaced live; once the body is fully sent we wait on Groq (indeterminate).
+    // Transcription runs on the server-side Groq key only for the authenticated owner. A visitor
+    // who brought their own Groq key forwards it as `apiKey` so anonymous BYOK-Groq users can
+    // transcribe. Upload progress is surfaced live; once the body is fully sent we wait on Groq.
+    const groqKey = getGroqKey();
     const stt = await transcribeWithProgress(
-      { audio: dataUri, filename: file.name, mimeType: file.type },
+      { audio: dataUri, filename: file.name, mimeType: file.type, ...(groqKey ? { apiKey: groqKey } : {}) },
       (loaded, total) => {
         if (!total) return;
         if (loaded >= total) {

--- a/src/client/assets/js/byok.js
+++ b/src/client/assets/js/byok.js
@@ -65,6 +65,8 @@ export const getRequestPayload = () => {
 
 export const getGoogleKey = () => getEntry("google")?.apiKey || "";
 
+export const getGroqKey = () => getEntry("groq")?.apiKey || "";
+
 // The shared free tier is offered to anonymous visitors who have not brought their own key.
 export const freeTierAvailable = () => Boolean(state.free?.enabled);
 

--- a/src/client/assets/js/state.js
+++ b/src/client/assets/js/state.js
@@ -9,6 +9,7 @@ export const state = {
   auth: { gateEnabled: false, authenticated: true },
   catalog: [],
   free: { enabled: false, provider: "cerebras", model: "gemma-4-31b", rateLimit: 5 },
+  transcription: { available: false, model: "" },
   // Two-way "conversation" translation: when the source is Auto-detect, this holds the other
   // party's language (learned from the first non-target message) so replies in the target
   // language are auto-translated back. Empty until learned; reset on clear / manual changes.
@@ -19,7 +20,7 @@ export const setLoading = (value) => {
   state.loading = Boolean(value);
 };
 
-export const setHealth = ({ model, models, maxTextLength, auth, catalog, free }) => {
+export const setHealth = ({ model, models, maxTextLength, auth, catalog, free, transcription }) => {
   state.model = model || state.model;
   state.models = Array.isArray(models) ? models : state.models;
   state.selectedModel = model || state.selectedModel;
@@ -27,4 +28,5 @@ export const setHealth = ({ model, models, maxTextLength, auth, catalog, free })
   if (auth) state.auth = auth;
   if (Array.isArray(catalog)) state.catalog = catalog;
   if (free) state.free = free;
+  if (transcription) state.transcription = transcription;
 };

--- a/src/client/assets/js/ui.js
+++ b/src/client/assets/js/ui.js
@@ -2,7 +2,7 @@ import { hasRtlText, languages, languageMap } from "./constants.js";
 import { elements } from "./dom.js";
 import { state } from "./state.js";
 import { translations, t, setLang, getLang } from "./i18n.js";
-import { getRuntime, hasUsableKey, isFreeMode } from "./byok.js";
+import { getRuntime, hasUsableKey, isFreeMode, getGroqKey } from "./byok.js";
 
 // The one model the free tier exposes, resolved from the server-reported catalog.
 export const freeModelList = () => {
@@ -141,6 +141,15 @@ export const updateKeyGate = () => {
   elements.translateButton.disabled = !available || state.loading;
 };
 
+// Audio transcription is available when the server reports the owner Groq key (health signal)
+// or the visitor has brought their own Groq key. Mirrors the live-availability pattern.
+export const transcriptionAvailable = () =>
+  Boolean(state.transcription?.available) || Boolean(getGroqKey());
+
+export const updateAudioAvailability = () => {
+  if (elements.audioButton) elements.audioButton.hidden = !transcriptionAvailable();
+};
+
 // AC07: the composer pill signals when there is something to send.
 const syncHasText = () => {
   const pill = elements.inputText.closest(".input-pill");
@@ -213,6 +222,7 @@ export const applyHealth = () => {
   populateModelSelect(models, selected);
   updateCharacterCount();
   updateKeyGate();
+  updateAudioAvailability();
 };
 
 // ---- Conversation bubbles ----

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -83,7 +83,7 @@
                 <span id="characterCount">0 / 8000</span>
               </div>
               <div class="input-pill">
-                <button class="attach-btn" id="audioButton" type="button" data-i18n-aria="audioUpload" aria-label="Upload audio or song">
+                <button class="attach-btn" id="audioButton" type="button" data-i18n-aria="audioUpload" aria-label="Upload audio or song" hidden>
                   <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
                 </button>
                 <input type="file" id="audioInput" accept="audio/*" hidden>

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -100,6 +100,7 @@ export const createApp = () => {
       maxTextLength: env.maxTextLength,
       chat: { ...chatConfig, models: active.models, defaultModel: active.selectedModel },
       live: { available: Boolean(google?.configured) && authenticated, model: "gemini-3.5-live-translate-preview" },
+      transcription: { available: authenticated && Boolean(env.groqApiKey), model: env.groqSttModel },
       catalog: providerCatalog.map((provider) => ({ id: provider.id, label: provider.label, models: publicModels(provider) })),
       auth: { gateEnabled: gateEnabled(), authenticated },
       free: freeTierInfo()
@@ -153,10 +154,11 @@ export const createApp = () => {
     legacyHeaders: false
   }), chatRouter);
 
-  // Audio/song transcription via Groq Whisper. Owner uses the server GROQ_API_KEY; anonymous
-  // visitors share it through the same free-tier limiter, plus a tighter per-route cap since
-  // each request spends real audio-minutes on the shared key.
-  app.use("/api/transcribe", freeTierLimiter, rateLimit({
+  // Audio/song transcription via Groq Whisper. The server GROQ_API_KEY is owner-only (see
+  // transcription.service.js); anonymous visitors can only transcribe with their own BYOK Groq
+  // key, so no free-tier limiter here — just a tighter per-route cap bounding the owner key,
+  // since each request spends real audio-minutes.
+  app.use("/api/transcribe", rateLimit({
     windowMs: 60 * 1000,
     limit: 10,
     standardHeaders: true,

--- a/src/server/config/providers.js
+++ b/src/server/config/providers.js
@@ -44,6 +44,23 @@ export const providerCatalog = [
       { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", vision: true },
       { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", vision: true }
     ]
+  },
+  {
+    id: "groq",
+    label: "Groq",
+    baseUrl: "https://api.groq.com/openai/v1",
+    envKey: "GROQ_API_KEY",
+    envBaseUrl: "GROQ_BASE_URL",
+    tokenParam: "max_completion_tokens",
+    defaultModel: "llama-3.3-70b-versatile",
+    models: [
+      { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B Versatile", vision: false },
+      { id: "llama-3.1-8b-instant", label: "Llama 3.1 8B Instant", vision: false },
+      { id: "meta-llama/llama-4-scout-17b-16e-instruct", label: "Llama 4 Scout 17B (vision)", vision: true },
+      { id: "qwen/qwen3-32b", label: "Qwen3 32B", vision: false },
+      { id: "openai/gpt-oss-120b", label: "GPT-OSS 120B", vision: false },
+      { id: "openai/gpt-oss-20b", label: "GPT-OSS 20B", vision: false }
+    ]
   }
 ];
 

--- a/src/server/services/free-tier.service.js
+++ b/src/server/services/free-tier.service.js
@@ -6,6 +6,10 @@ import { getProviderRuntime } from "./settings.store.js";
 // server-funded model. To keep the shared key safe it is locked to one provider/model,
 // the output tokens are capped, and every request is rate limited per visitor.
 
+// Providers that may never fund anonymous free-tier traffic, even if set as FREE_PROVIDER.
+// Groq's server key is owner-only (it also powers Whisper transcription).
+const FREE_BLOCKED = new Set(["groq"]);
+
 const freeProvider = () => providerMap[env.freeProvider];
 
 const freeModelId = () => {
@@ -22,7 +26,7 @@ const freeModelId = () => {
 export const freeTierEnabled = () => {
   if (!env.freeTierEnabled) return false;
   const provider = freeProvider();
-  if (!provider) return false;
+  if (!provider || FREE_BLOCKED.has(provider.id)) return false;   // groq is never a free provider
   return Boolean(getProviderRuntime(provider.id).apiKey);
 };
 

--- a/src/server/services/transcription.service.js
+++ b/src/server/services/transcription.service.js
@@ -4,13 +4,16 @@ import { HttpError } from "../utils/http-error.js";
 // Groq's free tier caps uploads at 25 MB; we also bound decoded size defensively.
 const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
 
-const friendly = (status, raw) => {
+const friendly = (status, raw, usedClientKey) => {
   const message = String(raw || "");
   if (status === 429 || /quota|rate.?limit|exceeded/i.test(message)) {
     return "Groq rate limit or quota reached. Wait a moment and try again.";
   }
   if (status === 401 || status === 403 || /api key|unauthor|permission/i.test(message)) {
-    return "The Groq API key was rejected. Check GROQ_API_KEY on the server.";
+    // Point BYOK users at their own key; only the owner's server key is theirs to fix.
+    return usedClientKey
+      ? "Your Groq API key was rejected. Check the key in Settings."
+      : "The Groq API key was rejected. Check GROQ_API_KEY on the server.";
   }
   if (status === 413 || /too large|maximum|file size/i.test(message)) {
     return "The audio file is too large for transcription (max 25 MB).";
@@ -18,15 +21,15 @@ const friendly = (status, raw) => {
   return message.length > 200 ? `${message.slice(0, 200)}…` : (message || "Transcription failed");
 };
 
-const parseErrorMessage = async (response) => {
+const parseErrorMessage = async (response, usedClientKey) => {
   const text = await response.text();
-  if (!text) return friendly(response.status, response.statusText || "Transcription failed");
+  if (!text) return friendly(response.status, response.statusText || "Transcription failed", usedClientKey);
   try {
     const data = JSON.parse(text);
     const raw = data?.error?.message || data?.error || data?.message || text;
-    return friendly(response.status, typeof raw === "string" ? raw : JSON.stringify(raw));
+    return friendly(response.status, typeof raw === "string" ? raw : JSON.stringify(raw), usedClientKey);
   } catch {
-    return friendly(response.status, text);
+    return friendly(response.status, text, usedClientKey);
   }
 };
 
@@ -51,16 +54,20 @@ export const transcribeAudio = async ({ audio, filename, mimeType, apiKey, authe
     throw new HttpError(413, "The audio file is too large (max 25 MB).");
   }
 
-  // Key resolution mirrors the app's philosophy: a caller-supplied Groq key wins; otherwise
-  // the server-side GROQ_API_KEY is used for the owner, and for anonymous visitors only when
-  // the free tier is switched on (route-level rate limiting bounds abuse of the shared key).
+  // A caller-supplied Groq key (BYOK) may be used by anyone. Otherwise the server-side
+  // GROQ_API_KEY is spent ONLY for the authenticated owner. Anonymous/free-tier visitors
+  // get NO server key and must bring their own Groq key. (No free-tier branch here.)
   const clientKey = String(apiKey || "").trim();
-  if (!clientKey && !authenticated && (!env.freeTierEnabled || !env.groqApiKey)) {
-    throw new HttpError(401, "Log in as the owner or provide a Groq API key to transcribe audio.");
-  }
-  const key = clientKey || env.groqApiKey;
-  if (!key) {
-    throw new HttpError(401, "Transcription is not configured (no Groq API key on the server).");
+  let key;
+  if (clientKey) {
+    key = clientKey;
+  } else if (authenticated) {
+    key = env.groqApiKey;
+    if (!key) {
+      throw new HttpError(503, "Transcription is not configured (no GROQ_API_KEY on the server).");
+    }
+  } else {
+    throw new HttpError(401, "Log in as the owner or add your own Groq API key in Settings to transcribe audio.");
   }
 
   const form = new FormData();
@@ -78,7 +85,7 @@ export const transcribeAudio = async ({ audio, filename, mimeType, apiKey, authe
   });
 
   if (!response.ok) {
-    throw new HttpError(response.status, await parseErrorMessage(response));
+    throw new HttpError(response.status, await parseErrorMessage(response, Boolean(clientKey)));
   }
 
   const data = await response.json();


### PR DESCRIPTION
Adds **Groq** as a first-class OpenAI-compatible provider for translation/chat, with its server key **locked to the owner** and audio transcription **gated on availability**. Built via a critic → worker → QA loop; model IDs were pulled **live from Groq's `/models` endpoint**, not guessed.

## Provider
`providers.js` gains a `groq` entry (`baseUrl https://api.groq.com/openai/v1`, `tokenParam max_completion_tokens`) with **6 curated real models**: `llama-3.3-70b-versatile` (default), `llama-3.1-8b-instant`, `meta-llama/llama-4-scout-17b-16e-instruct` (vision), `qwen/qwen3-32b`, `openai/gpt-oss-120b`, `openai/gpt-oss-20b`. Appears in the BYOK + owner Settings UI automatically; usable for translation and chat. (TTS/guard/agentic models deliberately excluded.)

## Owner-only key (the security core)
- The env **`GROQ_API_KEY` is spendable only by the authenticated owner**; everyone else must bring their own Groq key (BYOK).
- `transcription.service.js`: **deletes the free-tier branch that previously let anonymous visitors spend the env key** (the leak). Now BYOK key for anyone → env key only when authenticated (401 anon-no-key, 503 owner-no-env-key).
- `free-tier.service.js`: a `FREE_BLOCKED` guard so Groq can never become the free provider.
- Chat/translate was already owner-only via `resolveRuntime` (BYOK → owner-env → free=cerebras) — confirmed, unchanged.
- A rejected **BYOK** key now says *"check the key in Settings"* instead of misdirecting to the server key.

## Availability + gating
- `/api/health` gains `transcription: { available, model }` (`available` = owner-auth **and** env key set; booleans only).
- Client: `byok.getGroqKey()`; `handleAudioFile` forwards a BYOK Groq key as `apiKey`; the **audio button ships hidden** and only appears when transcription is available (owner env key **or** a local BYOK Groq key), re-evaluated on every key change.

## Docs
README + `.env.example`: a Groq section (owner-only key + owner-gate caveat, BYOK for others, the 6 models, Whisper STT models + `GROQ_STT_MODEL`/`GROQ_BASE_URL`, when audio & Groq translation turn on). `.env.example` ships an empty `GROQ_API_KEY=`.

## Verified end-to-end (live)
| Path | Result |
|---|---|
| Anonymous transcribe (no key) | **401** — env key protected |
| BYOK transcribe | **200** |
| Owner transcribe (env key via login) | **200** |
| Groq translation (`llama-3.3-70b-versatile`) | **200** |
| `health.transcription.available` | anon `false`, owner `true` |

QA: adversarial security review returned **all-pass** on the key-leak audit; correctness review found no defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)