### PR TITLE
docs: correct live demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A mobile-first multilingual translator, AI chat, and music-learning companion built around openly licensed music and user-connected Spotify playlists. Translator combines natural translation with synchronized lyrics, contextual Persian translation, personal learning collections, artist catalogs, and optional 24/7 audio radio.
 
-[Live app](https://server.raminexch.store) · [Report a bug](https://github.com/Kusarok/translator/issues) · [Security](SECURITY.md) · [Privacy](PRIVACY.md)
+[Live app](https://translate.raminexch.store) · [Report a bug](https://github.com/Kusarok/translator/issues) · [Security](SECURITY.md) · [Privacy](PRIVACY.md)
 
 > This repository contains application source code only. Runtime databases, downloaded media, lyrics, user data, OAuth secrets, provider keys, and deployment-specific radio sources belong in ignored local configuration and storage.
 

--- a/scripts/sync-open-music.js
+++ b/scripts/sync-open-music.js
@@ -10,7 +10,7 @@ import { config } from "../services/media-worker/config.js";
 import { createId } from "../services/media-worker/database/index.js";
 import { repositories } from "../services/media-worker/persistence.js";
 
-const USER_AGENT = "TranslatorOpenMusic/1.0 (+https://server.raminexch.store)";
+const USER_AGENT = "TranslatorOpenMusic/1.0 (+https://translate.raminexch.store)";
 const CATALOG = Object.freeze({
   id: "josh-woodward",
   artist: "Josh Woodward",

--- a/services/media-worker/modules/artists/musicbrainz.provider.js
+++ b/services/media-worker/modules/artists/musicbrainz.provider.js
@@ -1,4 +1,4 @@
-const USER_AGENT = "Translator/1.0 (https://server.raminexch.store)";
+const USER_AGENT = "Translator/1.0 (https://translate.raminexch.store)";
 let nextRequestAt = 0;
 let requestTail = Promise.resolve();
 


### PR DESCRIPTION
## What changed
- updated the README live demo link to `https://translate.raminexch.store`
- updated the MusicBrainz/open-music client contact URLs to use the canonical project domain

## Why
The previously documented `server.raminexch.store` address was outdated. This keeps the public documentation and outbound catalog client identification aligned with the active demo.

## Validation
- confirmed the live URL responds with HTTP 200
- `node --check` passed for both edited JavaScript files
- `npm test` passed (53/53)
- `git diff --check` passed