### PR TITLE
Add personal radio, backups, and secret hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ PORTS=8080
 TRUST_PROXY=
 MAX_TEXT_LENGTH=8000
 APP_DATA_DIR=./data
+BACKUP_DIR=./backups
+BACKUP_RETENTION_DAYS=7
 
 # Private loopback media-worker service. The browser only uses /api/media on the main app.
 MEDIA_WORKER_URL=http://127.0.0.1:8090

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .env
 .env.radio
 data/
+backups/
 settings.json
 npm-debug.log*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The music experience is designed as a guided language-learning journey. Learners
 - Personal learning playlists, recent plays, favorites, and progress.
 - Configurable daily limit for preparing previously uncached songs.
 - Optional audio-only live radio with background Media Session controls.
+- Guest listening for verified open-license songs and the deployment radio catalog; accounts are only required for personal libraries and non-public catalog items.
+- Private user-saved HTTPS radio links with editable station names.
 
 ## Architecture
 
@@ -152,6 +154,8 @@ RADIO_JAVAN_URLS=https://licensed.example/javan.m3u8
 
 Only configure streams you are authorized to access and relay. A station without a configured source is omitted from the public station list.
 
+The deployment radio catalog is available without signing in. Signed-in listeners can also save their own HTTPS audio stream links, rename them, and remove them later; these personal links stay attached to that account and are never added to the shared station catalog. Browser playback of a personal HLS source still depends on that source permitting browser access.
+
 See [.env.example](.env.example) for every setting and [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for production installation.
 
 ## Open music catalog
@@ -170,8 +174,8 @@ Runtime storage stays inside this project by default:
 
 ```text
 data/
-  accounts/       user accounts and sessions
-  database/       SQLite database and WAL files
+  app-secret.key  local encryption key (mode 0600)
+  database/       accounts, sessions, personal stations and media metadata
   media/          prepared media
   tracks/         per-track records
   lyrics/         source lyrics
@@ -181,7 +185,7 @@ data/
   radio/          radio-worker buffers
 ```
 
-Back up `data/` and `.env` separately. Neither belongs in source control.
+`npm run backup` creates a consistent local metadata snapshot under ignored `backups/`. It includes databases, licenses, lyrics, translations, artwork and the local encryption key, but intentionally excludes the large `data/media/` audio cache. Keep an additional filesystem backup if prepared audio must survive disk loss. Neither runtime data nor backups belong in source control.
 
 ## Commands
 
@@ -193,6 +197,7 @@ Back up `data/` and `.env` separately. Neither belongs in source control.
 | `node services/radio-worker/server.js` | Start only the radio worker |
 | `npm run media:install` | Create the Python environment and install yt-dlp/spotDL |
 | `npm run music:sync-open` | Import an explicitly licensed open catalog |
+| `npm run backup` | Create a local metadata/database backup |
 | `npm test` | Run the Node test suite |
 
 ## Production checklist
@@ -203,7 +208,7 @@ Before exposing a deployment:
 2. Generate unique provider/OAuth credentials and keep them outside Git.
 3. Restrict worker ports to loopback/private networking.
 4. Configure `OWNER_USERNAME` and `OWNER_PASSWORD` if server-funded keys are enabled.
-5. Back up the SQLite database, WAL files, and content directories together.
+5. Enable `translator-backup.timer` and separately back up `data/media/` when cached audio must be retained.
 6. Confirm licenses for every media source, lyric source, artwork, and radio stream.
 7. Publish a deployment-specific privacy policy and contact method.
 8. Run `npm test`, review `git diff`, and scan Git history for secrets.

--- a/deploy/systemd/media-worker.service
+++ b/deploy/systemd/media-worker.service
@@ -2,7 +2,7 @@
 Description=Translator Media Worker
 After=network-online.target
 Wants=network-online.target
-PartOf=translator.target
+PartOf=translator.target translator.service
 
 [Service]
 Type=simple

--- a/deploy/systemd/media-worker.service
+++ b/deploy/systemd/media-worker.service
@@ -16,6 +16,14 @@ Restart=always
 RestartSec=5
 NoNewPrivileges=true
 PrivateTmp=true
+PrivateDevices=true
+UMask=0077
+ProtectSystem=full
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
 
 [Install]
 WantedBy=translator.target

--- a/deploy/systemd/radio-worker.service
+++ b/deploy/systemd/radio-worker.service
@@ -9,13 +9,23 @@ Type=simple
 WorkingDirectory=/root/github/translator
 EnvironmentFile=-/root/github/translator/.env
 EnvironmentFile=-/root/github/translator/.env.radio
-Environment=RADIO_WORKER_HOST=0.0.0.0
+Environment=RADIO_WORKER_HOST=127.0.0.1
 Environment=RADIO_WORKER_PORT=8091
 Environment=RADIO_STORAGE_DIR=/root/github/translator/data/radio
 Environment=NODE_ENV=production
 ExecStart=/usr/bin/node services/radio-worker/server.js
 Restart=always
 RestartSec=5
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=full
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
 
 [Install]
 WantedBy=translator.target

--- a/deploy/systemd/radio-worker.service
+++ b/deploy/systemd/radio-worker.service
@@ -2,7 +2,7 @@
 Description=Translator Live Radio Worker
 After=network-online.target
 Wants=network-online.target
-PartOf=translator.target
+PartOf=translator.target translator.service
 
 [Service]
 Type=simple

--- a/deploy/systemd/translator-backup.service
+++ b/deploy/systemd/translator-backup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Translator local metadata backup
+
+[Service]
+Type=oneshot
+WorkingDirectory=/root/github/translator
+EnvironmentFile=-/root/github/translator/.env
+Environment=NODE_ENV=production
+ExecStart=/usr/bin/node scripts/backup-data.js
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+

--- a/deploy/systemd/translator-backup.timer
+++ b/deploy/systemd/translator-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily Translator metadata backup
+
+[Timer]
+OnCalendar=*-*-* 03:15:00 UTC
+RandomizedDelaySec=20m
+Persistent=true
+Unit=translator-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/translator-web.service
+++ b/deploy/systemd/translator-web.service
@@ -3,7 +3,7 @@ Description=Translator Web Server
 After=network-online.target media-worker.service radio-worker.service
 Wants=network-online.target
 Requires=media-worker.service radio-worker.service
-PartOf=translator.target
+PartOf=translator.target translator.service
 
 [Service]
 Type=simple

--- a/deploy/systemd/translator-web.service
+++ b/deploy/systemd/translator-web.service
@@ -15,6 +15,14 @@ Restart=on-failure
 RestartSec=5
 NoNewPrivileges=true
 PrivateTmp=true
+PrivateDevices=true
+UMask=0077
+ProtectSystem=full
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
 
 [Install]
 WantedBy=translator.target

--- a/deploy/systemd/translator.service
+++ b/deploy/systemd/translator.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Translator application compatibility service
+Requires=translator-web.service media-worker.service radio-worker.service
+After=translator-web.service media-worker.service radio-worker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/true

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express-rate-limit": "^8.6.0",
         "google-auth-library": "^10.9.0",
         "helmet": "^8.3.0",
+        "hls.js": "1.6.16",
         "ws": "^8.21.1"
       },
       "engines": {
@@ -611,6 +612,12 @@
       "funding": {
         "url": "https://github.com/sponsors/EvanHahn"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-rate-limit": "^8.6.0",
     "google-auth-library": "^10.9.0",
     "helmet": "^8.3.0",
+    "hls.js": "1.6.16",
     "ws": "^8.21.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start:media": "node services/media-worker/server.js",
     "media:install": "node scripts/install-media-tools.js",
     "music:sync-open": "node scripts/sync-open-music.js",
+    "backup": "node scripts/backup-data.js",
     "test": "node --test"
   },
   "dependencies": {

--- a/scripts/backup-data.js
+++ b/scripts/backup-data.js
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const root = path.resolve(process.cwd());
+const dataDir = path.resolve(process.env.APP_DATA_DIR || path.join(root, "data"));
+const backupRoot = path.resolve(process.env.BACKUP_DIR || path.join(root, "backups"));
+const retentionDays = Math.max(1, Number.parseInt(process.env.BACKUP_RETENTION_DAYS || "7", 10));
+const stamp = new Date().toISOString().replaceAll(":", "-").replace(".", "-");
+const destination = path.join(backupRoot, stamp);
+
+if (!dataDir.startsWith(`${root}${path.sep}`) || !backupRoot.startsWith(`${root}${path.sep}`)) {
+  throw new Error("Data and backup directories must stay inside the translator project.");
+}
+fs.mkdirSync(destination, { recursive: true, mode: 0o700 });
+
+const copyNames = ["settings.json", "app-secret.key", "lyrics", "translations", "licenses", "artwork", "tracks", "radio"];
+for (const name of copyNames) {
+  const source = path.join(dataDir, name);
+  if (fs.existsSync(source)) fs.cpSync(source, path.join(destination, name), { recursive: true, preserveTimestamps: true });
+}
+
+const databaseSource = path.join(dataDir, "database");
+const databaseDestination = path.join(destination, "database");
+fs.mkdirSync(databaseDestination, { recursive: true, mode: 0o700 });
+for (const name of fs.existsSync(databaseSource) ? fs.readdirSync(databaseSource) : []) {
+  if (!name.endsWith(".sqlite")) continue;
+  const source = path.join(databaseSource, name), target = path.join(databaseDestination, name);
+  const db = new DatabaseSync(source, { readOnly: true });
+  db.exec(`VACUUM INTO '${target.replaceAll("'", "''")}'`);
+  db.close(); fs.chmodSync(target, 0o600);
+}
+
+fs.writeFileSync(path.join(destination, "backup.json"), JSON.stringify({ createdAt: new Date().toISOString(), mediaIncluded: false,
+  note: "Database, licenses, lyrics, translations, artwork and application secrets. Large audio media is excluded." }, null, 2), { mode: 0o600 });
+
+const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+for (const entry of fs.readdirSync(backupRoot, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const target = path.join(backupRoot, entry.name);
+  if (fs.statSync(target).mtimeMs < cutoff) fs.rmSync(target, { recursive: true, force: true });
+}
+console.log(`Backup created: ${destination}`);

--- a/services/media-worker/repositories/index.js
+++ b/services/media-worker/repositories/index.js
@@ -28,6 +28,11 @@ export const createRepositories = (db) => ({
   },
   licenses: {
     findForTrack: (trackId) => db.prepare("SELECT * FROM track_licenses WHERE track_id=?").get(trackId) || null,
+    isPublicTrack: (trackId) => Boolean(db.prepare(`SELECT 1 FROM track_licenses
+      WHERE track_id=? AND covers_recording=1 AND covers_composition=1 AND covers_lyrics=1
+      AND verified_at IS NOT NULL AND TRIM(evidence_url)!=''
+      AND UPPER(REPLACE(REPLACE(TRIM(license_code),' ','-'),'_','-')) IN
+        ('CC0','CC0-1.0','PUBLIC-DOMAIN','PDM-1.0','CC-BY-4.0','CC-BY-SA-4.0')`).get(trackId)),
     upsert(input) {
       const current = this.findForTrack(input.trackId);
       const stamp = now(), id = current?.id || input.id || createId("license");
@@ -135,6 +140,11 @@ export const createRepositories = (db) => ({
     findById: (id) => db.prepare("SELECT * FROM media_assets WHERE id = ?").get(id) || null,
     findByProviderId: (provider, providerMediaId) => db.prepare("SELECT * FROM media_assets WHERE provider=? AND provider_media_id=?").get(provider, providerMediaId) || null,
     findReadyForTrack: (trackId) => db.prepare("SELECT * FROM media_assets WHERE track_id=? AND status='ready' ORDER BY updated_at DESC LIMIT 1").get(trackId) || null,
+    findPublicById: (id) => db.prepare(`SELECT m.* FROM media_assets m JOIN track_licenses tl ON tl.track_id=m.track_id
+      WHERE m.id=? AND m.status='ready' AND tl.covers_recording=1 AND tl.covers_composition=1 AND tl.covers_lyrics=1
+      AND tl.verified_at IS NOT NULL AND TRIM(tl.evidence_url)!=''
+      AND UPPER(REPLACE(REPLACE(TRIM(tl.license_code),' ','-'),'_','-')) IN
+        ('CC0','CC0-1.0','PUBLIC-DOMAIN','PDM-1.0','CC-BY-4.0','CC-BY-SA-4.0')`).get(id) || null,
     upsert(input) {
       const existing = input.providerMediaId ? this.findByProviderId(input.provider, input.providerMediaId) : null;
       const stamp = now(), id = existing?.id || input.id || createId("media");
@@ -244,6 +254,20 @@ export const createRepositories = (db) => ({
         LEFT JOIN track_licenses tl ON tl.track_id=t.id
         WHERE EXISTS(SELECT 1 FROM lyrics l WHERE l.track_id=t.id)
         ORDER BY m.updated_at DESC,t.updated_at DESC LIMIT ?`).all(userId, limit);
+    },
+    publicCatalog(limit = 500) {
+      return db.prepare(`SELECT t.*,a.id AS artwork_id,m.id AS media_id,tl.license_code,tl.license_url,
+        tl.rights_holder,tl.attribution_text,tl.evidence_url
+        FROM tracks t
+        JOIN media_assets m ON m.id=(SELECT id FROM media_assets WHERE track_id=t.id AND status='ready' ORDER BY updated_at DESC LIMIT 1)
+        JOIN track_licenses tl ON tl.track_id=t.id
+        LEFT JOIN artwork_assets a ON a.track_id=t.id
+        WHERE EXISTS(SELECT 1 FROM lyrics l WHERE l.track_id=t.id)
+          AND tl.covers_recording=1 AND tl.covers_composition=1 AND tl.covers_lyrics=1
+          AND tl.verified_at IS NOT NULL AND TRIM(tl.evidence_url)!=''
+          AND UPPER(REPLACE(REPLACE(TRIM(tl.license_code),' ','-'),'_','-')) IN
+            ('CC0','CC0-1.0','PUBLIC-DOMAIN','PDM-1.0','CC-BY-4.0','CC-BY-SA-4.0')
+        ORDER BY m.updated_at DESC,t.updated_at DESC LIMIT ?`).all(limit);
     },
     continueLearning(userId = "usr_legacy", limit = 8) {
       if (typeof userId === "number") { limit = userId; userId = "usr_legacy"; }

--- a/services/media-worker/server.js
+++ b/services/media-worker/server.js
@@ -8,7 +8,7 @@ import { safeMediaPath } from "./storage.js";
 import { cacheTrackLyrics, cacheTranslation, findTrackForReference, getCachedLesson, getCachedLessonByTrackId, reindexCachedLyrics } from "./services/lesson-cache.service.js";
 import { repositories } from "./persistence.js";
 import path from "node:path";
-import { addTrackToPlaylist, createLearningPlaylist, deleteLearningPlaylist, getPlaylistDetail, importSpotifyPlaylist, libraryOverview, openLibraryTrack, removeTrackFromPlaylist, updateLearningPlaylist, updateTrackProgress } from "./services/library.service.js";
+import { addTrackToPlaylist, createLearningPlaylist, deleteLearningPlaylist, getPlaylistDetail, importSpotifyPlaylist, libraryOverview, openLibraryTrack, openPublicLibraryTrack, publicLibraryOverview, removeTrackFromPlaylist, updateLearningPlaylist, updateTrackProgress } from "./services/library.service.js";
 import { createLyricsSearch, getLyricsSearch, prepareSearchResult } from "./modules/search/search.service.js";
 import { createArtistCatalog, discoverArtists, getArtistCatalog, prepareArtistCatalogItem } from "./modules/artists/artist.service.js";
 import { dueTranslationJobs, getTranslationJobForTrack, publicTranslationJob, scheduleTranslationJob, updateTranslationJob } from "./services/translation-job.service.js";
@@ -113,6 +113,12 @@ const server = http.createServer(async (req, res) => {
       return json(res, 200, { ok: true, capabilities: capabilities(), platforms: platformCatalog() });
     }
     if (req.method === "GET" && url.pathname === "/library") return json(res, 200, libraryOverview(requestUser(req)));
+    if (req.method === "GET" && url.pathname === "/public/library") return json(res, 200, publicLibraryOverview());
+    const publicTrackMatch = /^\/public\/library\/tracks\/(trk_[A-Za-z0-9-]+)$/.exec(url.pathname);
+    if (req.method === "GET" && publicTrackMatch) {
+      const lesson = openPublicLibraryTrack(publicTrackMatch[1]);
+      return lesson ? json(res, 200, lesson) : json(res, 404, { error: "Open-license track not found." });
+    }
     if (req.method === "POST" && url.pathname === "/artists/discover") return json(res, 200, { artists: await discoverArtists((await body(req)).name) });
     if (req.method === "POST" && url.pathname === "/artists") {
       const userId = requestUser(req);
@@ -242,6 +248,12 @@ const server = http.createServer(async (req, res) => {
       const artwork = repositories.artwork.findById(artworkMatch[1]);
       return artwork ? serveArtwork(res, artwork) : json(res, 404, { error: "Artwork not found." });
     }
+    const publicArtworkMatch = /^\/public\/artwork\/(art_[A-Za-z0-9-]+)$/.exec(url.pathname);
+    if (req.method === "GET" && publicArtworkMatch) {
+      const artwork = repositories.artwork.findById(publicArtworkMatch[1]);
+      return artwork && repositories.licenses.isPublicTrack(artwork.track_id)
+        ? serveArtwork(res, artwork) : json(res, 404, { error: "Open-license artwork not found." });
+    }
     const jobMatch = /^\/jobs\/([A-Za-z0-9_-]+)$/.exec(url.pathname);
     if (req.method === "GET" && jobMatch) {
       const job = getJob(jobMatch[1]);
@@ -251,6 +263,12 @@ const server = http.createServer(async (req, res) => {
     if (req.method === "GET" && mediaMatch) {
       const item = getMedia(mediaMatch[1]);
       return item ? serveFile(req, res, item, mediaMatch[2] === "download") : json(res, 404, { error: "Media not found." });
+    }
+    const publicMediaMatch = /^\/public\/media\/([A-Za-z0-9_-]+)\/stream$/.exec(url.pathname);
+    if (req.method === "GET" && publicMediaMatch) {
+      const allowed = repositories.media.findPublicById(publicMediaMatch[1]);
+      const item = allowed ? getMedia(publicMediaMatch[1]) : null;
+      return item ? serveFile(req, res, item, false) : json(res, 404, { error: "Open-license media not found." });
     }
     const deleteMatch = /^\/media\/([A-Za-z0-9_-]+)$/.exec(url.pathname);
     if (req.method === "DELETE" && deleteMatch) {

--- a/services/media-worker/services/library.service.js
+++ b/services/media-worker/services/library.service.js
@@ -4,8 +4,10 @@ import { config } from "../config.js";
 import { repositories } from "../persistence.js";
 import { getCachedLessonByTrackId } from "./lesson-cache.service.js";
 
-const artworkUrl = (row) => row.artwork_id ? `/api/media/artwork/${row.artwork_id}` : row.artwork_url || "";
-const trackView = (row) => ({
+const artworkUrl = (row, publicAccess = false) => row.artwork_id
+  ? `/api/media/${publicAccess ? "public/" : ""}artwork/${row.artwork_id}`
+  : row.artwork_url || "";
+const trackView = (row, publicAccess = false) => ({
   id: row.id,
   spotifyId: row.external_id,
   sourceUrl: row.source_url,
@@ -13,7 +15,7 @@ const trackView = (row) => ({
   artist: row.artist,
   album: row.album,
   duration: row.duration_seconds,
-  artwork: artworkUrl(row),
+  artwork: artworkUrl(row, publicAccess),
   mediaId: row.media_id || null,
   ready: Boolean(row.media_id),
   learningStatus: row.learning_status || "new",
@@ -24,6 +26,29 @@ const trackView = (row) => ({
     attribution: row.attribution_text, evidenceUrl: row.evidence_url
   } : null
 });
+
+export const publicLibraryOverview = () => ({
+  continueLearning: [], recent: [],
+  catalog: repositories.library.publicCatalog().map((row) => trackView(row, true)),
+  playlists: [], artists: [], quota: null,
+  spotify: { connected: false, configured: false }, guest: true
+});
+
+export const openPublicLibraryTrack = (trackId) => {
+  const track = repositories.tracks.findById(trackId);
+  if (!track || !repositories.licenses.isPublicTrack(trackId)) return null;
+  const lesson = getCachedLessonByTrackId(trackId);
+  if (!lesson) return null;
+  const media = lesson.mediaId ? repositories.media.findPublicById(lesson.mediaId) : null;
+  return {
+    ...lesson,
+    artwork: lesson.artwork?.startsWith("/api/media/artwork/")
+      ? lesson.artwork.replace("/api/media/artwork/", "/api/media/public/artwork/") : lesson.artwork,
+    streamUrl: media ? `/api/media/public/${media.id}/stream` : null,
+    downloadUrl: null,
+    media: media ? { id: media.id, streamUrl: `/api/media/public/${media.id}/stream`, downloadUrl: null } : null
+  };
+};
 
 const playlistView = (row) => ({
   id: row.id, source: row.source, externalId: row.external_id, name: row.name,

--- a/src/client/assets/css/login.css
+++ b/src/client/assets/css/login.css
@@ -10,6 +10,7 @@
 .login-gate[hidden] { display: none; }
 
 .login-card {
+  position: relative;
   width: min(100%, 390px);
   border: 1px solid var(--line, #2a2d31);
   border-radius: 24px;
@@ -18,6 +19,8 @@
   padding: 34px 26px 28px;
   text-align: center;
 }
+.login-close { position: absolute; inset-block-start: 14px; inset-inline-end: 14px; width: 36px; height: 36px; border: 0; border-radius: 50%; background: var(--surface-3); color: var(--text); font-size: 24px; }
+.login-guest { margin-top: 16px; border: 0; background: transparent; color: var(--muted); font: inherit; font-weight: 750; text-decoration: underline; text-underline-offset: 4px; }
 .login-logo { width: 62px; height: 62px; margin: 0 auto 18px; display: grid; place-items: center; border-radius: 20px; background: var(--grad-accent, #32d6c5); color: #06211e; font-size: 34px; font-weight: 900; box-shadow: var(--accent-glow); }
 .login-title { margin: 0; color: var(--text, #f0f2f5); font-size: 27px; font-weight: 900; letter-spacing: -.04em; }
 .login-subtitle { margin: 8px auto 24px; max-width: 290px; color: var(--muted, #8b9098); font-size: 14px; line-height: 1.55; }

--- a/src/client/assets/css/media.css
+++ b/src/client/assets/css/media.css
@@ -100,6 +100,19 @@ body.radio-is-playing .radio-station-card.is-active .radio-card-bars { display: 
 .radio-station-switcher strong { font-size: 12px; }.radio-station-switcher small { margin-top: 4px; color: rgba(255,255,255,.48); font-size: 9px; }
 .radio-station-switcher button > i { width: 7px; height: 7px; border-radius: 50%; background: rgba(255,255,255,.2); }
 .radio-station-switcher button.active > i { background: var(--radio-accent); box-shadow: 0 0 12px var(--radio-accent); }
+.radio-station-switcher-row { display: grid; grid-template-columns: minmax(0,1fr) auto; align-items: center; gap: 6px; }
+.radio-station-switcher-row > button { width: 100%; }
+.radio-personal-actions { display: grid; gap: 3px; }
+.radio-station-switcher .radio-personal-actions button { min-height: 28px; min-width: 52px; padding: 5px 8px; display: block; border-radius: 9px; color: rgba(255,255,255,.72); text-align: center; font-size: 9px; }
+.radio-add-station { width: 100%; min-height: 46px; margin-top: 9px; border: 1px dashed color-mix(in srgb,var(--radio-accent) 48%,transparent); border-radius: 15px; background: color-mix(in srgb,var(--radio-accent) 9%,transparent); color: #fff; font-weight: 800; }
+.radio-station-form { margin-top: 9px; padding: 12px; display: grid; gap: 10px; border: 1px solid rgba(255,255,255,.1); border-radius: 17px; background: rgba(0,0,0,.2); }
+.radio-station-form[hidden] { display: none; }
+.radio-station-form label { display: grid; gap: 5px; color: rgba(255,255,255,.62); font-size: 10px; font-weight: 750; }
+.radio-station-form input { min-width: 0; min-height: 42px; padding: 0 12px; border: 1px solid rgba(255,255,255,.12); border-radius: 12px; background: rgba(0,0,0,.26); color: #fff; font: inherit; }
+.radio-station-form > div { display: grid; grid-template-columns: 1fr 1.4fr; gap: 8px; }
+.radio-station-form > div button { min-height: 40px; border: 0; border-radius: 12px; background: rgba(255,255,255,.08); color: #fff; font-weight: 800; }
+.radio-station-form > div button:last-child { background: var(--radio-accent); color: #06211e; }
+.radio-station-form p { margin: 0; color: #ff9ca8; font-size: 10px; }
 #radioAudio { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
 body.radio-player-open .learn-bottom-nav,body.radio-player-open .radio-mini-player { display: none; }
 

--- a/src/client/assets/js/api.js
+++ b/src/client/assets/js/api.js
@@ -16,6 +16,7 @@ const request = async (url, options = {}) => {
   const data = await response.json().catch(() => ({}));
 
   if (!response.ok) {
+    if (response.status === 401) window.dispatchEvent(new CustomEvent("auth:required"));
     const fallback = response.status >= 500
       ? "Something went wrong on the server. Try again."
       : response.status === 404 ? "This item is no longer available." : "Couldn’t complete that action.";
@@ -82,6 +83,10 @@ export const logoutOwner = () => request("/api/auth/logout", { method: "POST" })
 
 export const getMediaHealth = () => request("/api/media/health");
 export const getRadioStations = () => request("/api/radio/stations");
+export const getPersonalRadioStations = () => request("/api/radio/my-stations");
+export const createPersonalRadioStation = (payload) => request("/api/radio/my-stations", { method: "POST", body: JSON.stringify(payload) });
+export const updatePersonalRadioStation = (id, payload) => request(`/api/radio/my-stations/${encodeURIComponent(id)}`, { method: "PATCH", body: JSON.stringify(payload) });
+export const deletePersonalRadioStation = (id) => request(`/api/radio/my-stations/${encodeURIComponent(id)}`, { method: "DELETE" });
 
 export const createMediaJob = (url) => request("/api/media/jobs", {
   method: "POST",

--- a/src/client/assets/js/app.js
+++ b/src/client/assets/js/app.js
@@ -36,7 +36,7 @@ import { getRuntime, getRequestPayload, updateModel, getGroqKey } from "./byok.j
 import { initLive, stopLive, setLiveAvailable, refreshLiveAvailability, applyLiveTranslations } from "./live.js";
 import { initViewportSizing } from "./viewport.js";
 import { initMedia } from "./media-app.js";
-import { checkAuth } from "./login.js";
+import { checkAuth, showLogin } from "./login.js";
 import { initMotion } from "./motion.js";
 import { initRadio } from "./radio-player.js";
 
@@ -61,7 +61,11 @@ const account = {
 };
 const renderAccount = () => {
   const user = state.auth?.user;
-  if (!user) return;
+  if (!user) {
+    account.initial.textContent = "↗";
+    account.toggle?.setAttribute("aria-label", "Sign in");
+    return;
+  }
   account.name.textContent = user.displayName || "Account";
   account.email.textContent = user.email || "";
   account.initial.textContent = (user.displayName || user.email || "U").trim().slice(0, 1).toUpperCase();
@@ -452,6 +456,7 @@ const bindEvents = () => {
     elements.inputText.focus(); elements.inputText.setSelectionRange(elements.inputText.value.length, elements.inputText.value.length);
   }));
   account.toggle?.addEventListener("click", (event) => {
+    if (!state.auth?.authenticated) { event.stopPropagation(); showLogin(); return; }
     event.stopPropagation(); account.menu.hidden = !account.menu.hidden;
     account.toggle.setAttribute("aria-expanded", String(!account.menu.hidden));
   });
@@ -508,7 +513,7 @@ const boot = async () => {
   initSettings(loadHealth);
   initByokUi(refreshAccessAfterKeyChange);
   initLive();
-  loadHealth();
+  await loadHealth();
   updateCharacterCount();
   updateDirection(elements.inputText);
 

--- a/src/client/assets/js/login.js
+++ b/src/client/assets/js/login.js
@@ -6,10 +6,13 @@ const errorEl = document.getElementById("loginError");
 const nameInput = document.getElementById("loginName");
 const passwordInput = document.getElementById("loginPassword");
 const googleButton = document.getElementById("googleLogin");
+const closeButton = document.getElementById("loginClose");
+const guestButton = document.getElementById("loginGuest");
 let mode = "login";
 let bound = false;
 
-const showLogin = () => { if (gate) gate.hidden = false; if (shell) shell.hidden = true; };
+export const showLogin = () => { if (gate) gate.hidden = false; if (shell) shell.hidden = false; };
+export const hideLogin = () => { if (gate) gate.hidden = true; };
 const showApp = () => { if (gate) gate.hidden = true; if (shell) shell.hidden = false; };
 const showError = (message) => { if (errorEl) { errorEl.textContent = message; errorEl.hidden = false; } };
 
@@ -46,6 +49,9 @@ const bind = () => {
   if (bound) return;
   bound = true;
   form?.addEventListener("submit", handleLogin);
+  closeButton?.addEventListener("click", hideLogin);
+  guestButton?.addEventListener("click", hideLogin);
+  window.addEventListener("auth:required", showLogin);
   document.querySelectorAll("[data-auth-mode]").forEach((item) => item.addEventListener("click", () => selectMode(item.dataset.authMode)));
 };
 
@@ -55,8 +61,10 @@ export const checkAuth = async () => {
     const data = await response.json();
     if (!data.auth?.authenticated) {
       googleButton.hidden = !data.auth?.googleEnabled;
-      bind(); showLogin(); return false;
+      document.body.dataset.authenticated = "false";
+      bind(); showApp(); return true;
     }
+    document.body.dataset.authenticated = "true";
     showApp(); return true;
-  } catch { bind(); showLogin(); return false; }
+  } catch { bind(); showApp(); return true; }
 };

--- a/src/client/assets/js/radio-player.js
+++ b/src/client/assets/js/radio-player.js
@@ -1,4 +1,4 @@
-import { getRadioStations } from "./api.js";
+import { createPersonalRadioStation, deletePersonalRadioStation, getPersonalRadioStations, getRadioStations, updatePersonalRadioStation } from "./api.js";
 
 const byId = (id) => document.getElementById(id);
 const ui = {
@@ -12,6 +12,9 @@ const ui = {
   mini: byId("radioMiniPlayer"), miniOpen: byId("radioMiniOpen"), miniArtwork: byId("radioMiniArtwork"),
   miniName: byId("radioMiniName"), miniLanguage: byId("radioMiniLanguage"), miniPlay: byId("radioMiniPlay"),
   miniClose: byId("radioMiniClose")
+  ,addStation: byId("radioAddStation"), stationForm: byId("radioStationForm"), stationName: byId("radioStationName"),
+  stationUrl: byId("radioStationUrl"), stationFormError: byId("radioStationFormError"),
+  stationCancel: byId("radioStationCancel"), stationSave: byId("radioStationSave")
 };
 
 const FAVORITES_KEY = "translator_radio_favorites";
@@ -26,6 +29,7 @@ let reconnectTimer = 0;
 let sleepTimer = 0;
 let sleepIndex = 0;
 let catalogRetry = 0;
+let editingStation = null;
 
 const favorites = () => {
   try { return new Set(JSON.parse(localStorage.getItem(FAVORITES_KEY) || "[]")); } catch { return new Set(); }
@@ -99,7 +103,9 @@ const attachStream = () => {
   if (!active) return;
   destroyStream();
   setStatus(active.live ? "Connecting to live stream…" : "Station is connecting…", "connecting");
-  const source = `${active.streamUrl}?v=${Date.now()}`;
+  const sourceUrl = new URL(active.streamUrl, location.origin);
+  if (!active.personal) sourceUrl.searchParams.set("v", Date.now());
+  const source = sourceUrl.href;
   ui.audio.src = source;
   ui.audio.load();
   if (wantsPlayback) ui.audio.play().catch(handlePlayFailure);
@@ -195,6 +201,7 @@ function renderCards() {
 
 function renderSwitcher() {
   ui.switcher.replaceChildren(...stations.map((station) => {
+    const row = document.createElement("div"); row.className = "radio-station-switcher-row";
     const button = document.createElement("button");
     button.type = "button";
     button.className = active?.id === station.id ? "active" : "";
@@ -208,9 +215,56 @@ function renderSwitcher() {
       selectStation(station, { open: false });
       closeStationPicker();
     });
-    return button;
+    row.append(button);
+    if (station.personal) {
+      const actions = document.createElement("span"); actions.className = "radio-personal-actions";
+      const edit = document.createElement("button"); edit.type = "button"; edit.textContent = "Edit"; edit.setAttribute("aria-label", `Edit ${station.name}`);
+      edit.addEventListener("click", () => showStationForm(station));
+      const remove = document.createElement("button"); remove.type = "button"; remove.textContent = "Delete"; remove.setAttribute("aria-label", `Delete ${station.name}`);
+      remove.addEventListener("click", async () => {
+        if (!confirm(`Delete ${station.name}?`)) return;
+        await deletePersonalRadioStation(station.id);
+        if (active?.id === station.id) stop();
+        stations = stations.filter((item) => item.id !== station.id); renderCards(); renderSwitcher();
+      });
+      actions.append(edit, remove); row.append(actions);
+    }
+    return row;
   }));
 }
+
+const showStationForm = (station = null) => {
+  if (document.body.dataset.authenticated !== "true") {
+    window.dispatchEvent(new CustomEvent("auth:required")); return;
+  }
+  editingStation = station;
+  ui.stationName.value = station?.name || "";
+  ui.stationUrl.value = station?.streamUrl || "";
+  ui.stationFormError.hidden = true;
+  ui.stationForm.hidden = false; ui.addStation.hidden = true;
+  ui.stationName.focus({ preventScroll: true });
+};
+
+const hideStationForm = () => {
+  editingStation = null; ui.stationForm.reset(); ui.stationForm.hidden = true; ui.addStation.hidden = false;
+};
+
+const saveStation = async (event) => {
+  event.preventDefault(); ui.stationSave.disabled = true; ui.stationFormError.hidden = true;
+  try {
+    const payload = { name: ui.stationName.value, streamUrl: ui.stationUrl.value };
+    const saved = editingStation
+      ? await updatePersonalRadioStation(editingStation.id, payload)
+      : await createPersonalRadioStation(payload);
+    saved.personal = true; saved.language = "Personal"; saved.artwork = "/icon-192.png";
+    saved.accent = "#58f1d5"; saved.accentAlt = "#23aeda"; saved.live = true;
+    const index = stations.findIndex((item) => item.id === saved.id);
+    if (index >= 0) stations[index] = saved; else stations.push(saved);
+    hideStationForm(); renderCards(); renderSwitcher();
+  } catch (error) {
+    ui.stationFormError.textContent = error.message || "Station could not be saved."; ui.stationFormError.hidden = false;
+  } finally { ui.stationSave.disabled = false; }
+};
 
 const openStationPicker = () => {
   if (!ui.stationSheet?.hidden) return;
@@ -285,6 +339,9 @@ export const initRadio = async () => {
   ui.stationTrigger?.addEventListener("click", openStationPicker);
   ui.stationSheetClose?.addEventListener("click", () => closeStationPicker());
   ui.stationSheetBackdrop?.addEventListener("click", () => closeStationPicker());
+  ui.addStation?.addEventListener("click", () => showStationForm());
+  ui.stationCancel?.addEventListener("click", hideStationForm);
+  ui.stationForm?.addEventListener("submit", saveStation);
   ui.stationSheet?.addEventListener("keydown", (event) => {
     if (event.key === "Escape") { event.preventDefault(); closeStationPicker(); }
   });
@@ -304,6 +361,11 @@ export const initRadio = async () => {
     try {
       const result = await getRadioStations();
       stations = Array.isArray(result.stations) ? result.stations : [];
+      try {
+        const personal = await getPersonalRadioStations();
+        stations.push(...(personal.stations || []).map((station) => ({ ...station, personal: true, language: "Personal",
+          artwork: "/icon-192.png", accent: "#58f1d5", accentAlt: "#23aeda", live: true })));
+      } catch { /* Guests still receive the public radio catalog. */ }
       renderCards();
       const remembered = stations.find((station) => station.id === localStorage.getItem(LAST_STATION_KEY));
       if (remembered) { active = remembered; paintActive(); ui.mini.hidden = true; document.body.classList.remove("radio-mini-active"); }

--- a/src/client/assets/js/radio-player.js
+++ b/src/client/assets/js/radio-player.js
@@ -1,4 +1,5 @@
 import { createPersonalRadioStation, deletePersonalRadioStation, getPersonalRadioStations, getRadioStations, updatePersonalRadioStation } from "./api.js";
+import Hls from "/assets/vendor/hls.mjs";
 
 const byId = (id) => document.getElementById(id);
 const ui = {
@@ -30,6 +31,7 @@ let sleepTimer = 0;
 let sleepIndex = 0;
 let catalogRetry = 0;
 let editingStation = null;
+let hls = null;
 
 const favorites = () => {
   try { return new Set(JSON.parse(localStorage.getItem(FAVORITES_KEY) || "[]")); } catch { return new Set(); }
@@ -71,6 +73,7 @@ const updateMediaSession = () => {
 const destroyStream = () => {
   clearTimeout(reconnectTimer);
   reconnectTimer = 0;
+  hls?.destroy(); hls = null;
   ui.audio.pause();
   ui.audio.removeAttribute("src");
   ui.audio.load();
@@ -106,6 +109,12 @@ const attachStream = () => {
   const sourceUrl = new URL(active.streamUrl, location.origin);
   if (!active.personal) sourceUrl.searchParams.set("v", Date.now());
   const source = sourceUrl.href;
+  if (active.personal && sourceUrl.pathname.toLowerCase().endsWith(".m3u8") && Hls.isSupported()) {
+    hls = new Hls({ enableWorker: false, lowLatencyMode: false, maxBufferLength: 30, backBufferLength: 0 });
+    hls.on(Hls.Events.MEDIA_ATTACHED, () => { if (wantsPlayback) ui.audio.play().catch(handlePlayFailure); });
+    hls.on(Hls.Events.ERROR, (_event, data) => { if (data.fatal) scheduleReconnect(2_000); });
+    hls.loadSource(source); hls.attachMedia(ui.audio); return;
+  }
   ui.audio.src = source;
   ui.audio.load();
   if (wantsPlayback) ui.audio.play().catch(handlePlayFailure);

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -42,6 +42,7 @@
     </svg>
     <div class="login-gate" id="loginGate" hidden>
       <div class="login-card">
+        <button class="login-close" id="loginClose" type="button" aria-label="Continue without signing in">×</button>
         <div class="login-logo" aria-hidden="true">♪</div>
         <h1 class="login-title">Your music, your progress</h1>
         <p class="login-subtitle">Listen online and learn languages with lyrics.</p>
@@ -61,6 +62,7 @@
           <button class="login-btn" id="loginBtn" type="submit">Sign in</button>
           <p class="login-error" id="loginError" hidden></p>
         </form>
+        <button class="login-guest" id="loginGuest" type="button">Continue with open music</button>
       </div>
     </div>
     <main class="app-shell" id="appShell" hidden>
@@ -480,6 +482,13 @@
                   <div class="radio-station-sheet-handle" aria-hidden="true"></div>
                   <header><div><span>LIVE RADIO</span><h2 id="radioStationSheetTitle">Choose a station</h2></div><button id="radioStationSheetClose" type="button" aria-label="Close station list">×</button></header>
                   <div class="radio-station-switcher" id="radioStationSwitcher"></div>
+                  <button class="radio-add-station" id="radioAddStation" type="button">+ Add your own station</button>
+                  <form class="radio-station-form" id="radioStationForm" hidden>
+                    <label>Station name<input id="radioStationName" maxlength="80" autocomplete="off" placeholder="My radio" required></label>
+                    <label>Secure stream URL<input id="radioStationUrl" type="url" inputmode="url" maxlength="2048" autocomplete="url" placeholder="https://…" required></label>
+                    <p id="radioStationFormError" role="alert" hidden></p>
+                    <div><button id="radioStationCancel" type="button">Cancel</button><button id="radioStationSave" type="submit">Save station</button></div>
+                  </form>
                 </section>
               </div>
               <audio id="radioAudio" preload="none"></audio>

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -77,6 +77,7 @@ export const createApp = () => {
           "https://www.facebook.com"
         ],
         imgSrc: ["'self'", "data:", "https:"],
+        mediaSrc: ["'self'", "https:"],
         objectSrc: ["'none'"],
         scriptSrc: ["'self'"],
         scriptSrcAttr: ["'none'"],
@@ -98,10 +99,15 @@ export const createApp = () => {
 
   // Every personal API is behind a real user session. Health and auth stay public
   // so the sign-in screen can render and create an account.
-  const PUBLIC_API = /^\/(health|auth)/;
+  const isPublicApi = (req) => {
+    if (/^\/(health|auth)(?:\/|$)/.test(req.path)) return true;
+    if (req.method === "GET" && (req.path === "/radio/stations" || /^\/radio\/stations\/[^/]+\/[^/]+$/.test(req.path))) return true;
+    if (req.method === "GET" && (req.path === "/media/library" || /^\/media\/public\/(?:artwork\/)?[^/]+(?:\/stream)?$/.test(req.path))) return true;
+    return req.method === "POST" && /^\/media\/library\/tracks\/trk_[A-Za-z0-9-]+\/open$/.test(req.path);
+  };
   app.use("/api", (req, res, next) => {
     if (readSession(req)) return next();
-    if (PUBLIC_API.test(req.path)) return next();
+    if (isPublicApi(req)) return next();
     return res.status(401).json({ error: "Authentication required." });
   });
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -31,6 +31,7 @@ const sendIndex = (res) => {
 };
 
 const jsDir = path.join(clientPath, "assets", "js");
+const hlsModulePath = path.join(__dirname, "../../node_modules/hls.js/dist/hls.mjs");
 
 const versionImports = (code) =>
   code.replace(/((?:from|import)\s*\(?\s*)(["'])(\.\.?\/[^"']+?\.js)\2/g,
@@ -64,7 +65,7 @@ export const createApp = () => {
       directives: {
         defaultSrc: ["'self'"],
         baseUri: ["'self'"],
-        connectSrc: ["'self'"],
+        connectSrc: ["'self'", "https:"],
         fontSrc: ["'self'"],
         formAction: ["'self'"],
         frameAncestors: ["'self'"],
@@ -94,6 +95,7 @@ export const createApp = () => {
 
   app.use(express.json({ limit: "15mb" }));
   app.get("/", (_req, res) => sendIndex(res));
+  app.get("/assets/vendor/hls.mjs", (_req, res) => res.sendFile(hlsModulePath, { headers: { "Cache-Control": "public, max-age=86400" } }));
   app.get(/^\/assets\/js\/.+\.js$/, serveModule);
   app.use(express.static(clientPath, { index: false }));
 

--- a/src/server/controllers/media.controller.js
+++ b/src/server/controllers/media.controller.js
@@ -1,4 +1,4 @@
-import { addLibraryPlaylistTrack, artworkStream, createLibraryArtist, createLibraryPlaylist, createLyricsSearchJob, createMediaJob, createSearchMediaJob, deleteLibraryPlaylist, discoverLibraryArtists, getLibrary, getLibraryArtist, getLibraryPlaylist, getLyricsSearchJob, getLyricsTranslationStatus as getCachedTranslationStatus, getMediaJob, mediaHealth, mediaStream, openCachedTrack, prepareLibraryArtistTrack, prepareLyricsSearchResult, removeLibraryPlaylistTrack, removeMedia, saveTrackProgress, updateLibraryPlaylist } from "../services/media-worker.service.js";
+import { addLibraryPlaylistTrack, artworkStream, createLibraryArtist, createLibraryPlaylist, createLyricsSearchJob, createMediaJob, createSearchMediaJob, deleteLibraryPlaylist, discoverLibraryArtists, getLibrary, getLibraryArtist, getLibraryPlaylist, getLyricsSearchJob, getLyricsTranslationStatus as getCachedTranslationStatus, getMediaJob, getPublicLibrary, getPublicTrack, mediaHealth, mediaStream, openCachedTrack, prepareLibraryArtistTrack, prepareLyricsSearchResult, publicArtworkStream, publicMediaStream, removeLibraryPlaylistTrack, removeMedia, saveTrackProgress, updateLibraryPlaylist } from "../services/media-worker.service.js";
 import { findSpotifyLyrics, translateLyrics } from "../services/lyrics.service.js";
 import { isOwnerAuthenticated, readSession } from "../services/auth.service.js";
 import { env } from "../config/env.js";
@@ -50,6 +50,22 @@ export const streamArtwork = async (req, res) => {
   upstream.pipe(res);
 };
 
+export const streamPublicMedia = async (req, res) => {
+  const upstream = await publicMediaStream(req.params.id, req.headers.range);
+  res.status(upstream.statusCode || 200);
+  for (const header of ["content-type", "content-length", "content-range", "accept-ranges", "cache-control"]) {
+    if (upstream.headers[header]) res.set(header, upstream.headers[header]);
+  }
+  upstream.on("error", () => res.destroy()); upstream.pipe(res);
+};
+
+export const streamPublicArtwork = async (req, res) => {
+  const upstream = await publicArtworkStream(req.params.id);
+  res.status(upstream.statusCode || 200);
+  for (const header of ["content-type", "content-length", "cache-control"]) if (upstream.headers[header]) res.set(header, upstream.headers[header]);
+  upstream.on("error", () => res.destroy()); upstream.pipe(res);
+};
+
 export const getLyrics = async (req, res) => {
   const lesson = await findSpotifyLyrics(req.body?.url);
   if (lesson?.trackId) await saveTrackProgress(readSession(req).id, lesson.trackId, { status: "new" });
@@ -81,8 +97,9 @@ export const lyricsTranslationStatus = async (req, res) => {
 const relay = (result, res) => res.status(result.status).json(result.data);
 const userId = (req) => readSession(req).id;
 export const library = async (req, res) => {
-  const result = await getLibrary(userId(req));
-  result.data.spotify.configured = Boolean(env.spotifyClientId && env.spotifyClientSecret && env.spotifyRedirectUri);
+  const session = readSession(req);
+  const result = session ? await getLibrary(session.id) : await getPublicLibrary();
+  if (session) result.data.spotify.configured = Boolean(env.spotifyClientId && env.spotifyClientSecret && env.spotifyRedirectUri);
   relay(result, res);
 };
 export const createPlaylist = async (req, res) => relay(await createLibraryPlaylist(userId(req), req.body), res);
@@ -91,7 +108,10 @@ export const updatePlaylist = async (req, res) => relay(await updateLibraryPlayl
 export const deletePlaylist = async (req, res) => relay(await deleteLibraryPlaylist(userId(req), req.params.id), res);
 export const addPlaylistTrack = async (req, res) => relay(await addLibraryPlaylistTrack(userId(req), req.params.id, req.body), res);
 export const removePlaylistTrack = async (req, res) => relay(await removeLibraryPlaylistTrack(userId(req), req.params.id, req.params.trackId), res);
-export const openTrack = async (req, res) => relay(await openCachedTrack(userId(req), req.params.id), res);
+export const openTrack = async (req, res) => {
+  const session = readSession(req);
+  relay(session ? await openCachedTrack(session.id, req.params.id) : await getPublicTrack(req.params.id), res);
+};
 export const trackProgress = async (req, res) => relay(await saveTrackProgress(userId(req), req.params.id, req.body), res);
 export const discoverArtists = async (req, res) => relay(await discoverLibraryArtists(req.body?.name), res);
 export const createArtist = async (req, res) => relay(await createLibraryArtist(userId(req), req.body), res);

--- a/src/server/controllers/radio.controller.js
+++ b/src/server/controllers/radio.controller.js
@@ -1,4 +1,7 @@
 import { getRadioHealth, getRadioStations, getRadioStream } from "../services/radio-worker.service.js";
+import { createUserRadioStation, deleteUserRadioStation, listUserRadioStations, updateUserRadioStation } from "../services/account.store.js";
+import { readSession } from "../services/auth.service.js";
+import { normalizeUserStation } from "../services/user-radio.service.js";
 
 const relay = (result, res) => res.status(result.status).json(result.data);
 
@@ -15,3 +18,14 @@ export const stream = async (req, res) => {
   upstream.on("error", () => res.destroy());
   upstream.pipe(res);
 };
+
+export const personalStations = (req, res) => res.json({ stations: listUserRadioStations(readSession(req).id) });
+export const createPersonalStation = (req, res) => res.status(201).json(
+  createUserRadioStation(readSession(req).id, normalizeUserStation(req.body))
+);
+export const updatePersonalStation = (req, res) => {
+  const station = updateUserRadioStation(readSession(req).id, req.params.id, normalizeUserStation(req.body));
+  return station ? res.json(station) : res.status(404).json({ error: "Station not found." });
+};
+export const deletePersonalStation = (req, res) => deleteUserRadioStation(readSession(req).id, req.params.id)
+  ? res.json({ ok: true }) : res.status(404).json({ error: "Station not found." });

--- a/src/server/routes/media.routes.js
+++ b/src/server/routes/media.routes.js
@@ -1,13 +1,16 @@
 import { Router } from "express";
 import rateLimit from "express-rate-limit";
 import { asyncHandler } from "../utils/async-handler.js";
-import { addPlaylistTrack, artist, createArtist, createJob, createPlaylist, createSearch, createSearchJob, deleteMedia, deletePlaylist, discoverArtists, getJob, getLyrics, getSearch, health, library, lyricsTranslationStatus, openTrack, playlist, prepareArtistTrack, prepareSearchResult, removePlaylistTrack, spotifyCallback, spotifyConnect, spotifyImportPlaylist, streamArtwork, streamMedia, trackProgress, translateSyncedLyrics, updatePlaylist } from "../controllers/media.controller.js";
+import { requireOwner } from "../services/auth.service.js";
+import { addPlaylistTrack, artist, createArtist, createJob, createPlaylist, createSearch, createSearchJob, deleteMedia, deletePlaylist, discoverArtists, getJob, getLyrics, getSearch, health, library, lyricsTranslationStatus, openTrack, playlist, prepareArtistTrack, prepareSearchResult, removePlaylistTrack, spotifyCallback, spotifyConnect, spotifyImportPlaylist, streamArtwork, streamMedia, streamPublicArtwork, streamPublicMedia, trackProgress, translateSyncedLyrics, updatePlaylist } from "../controllers/media.controller.js";
 
 export const mediaRouter = Router();
 const searchLimiter = rateLimit({ windowMs: 60 * 1000, limit: 20, standardHeaders: true, legacyHeaders: false });
 
 mediaRouter.get("/health", asyncHandler(health));
 mediaRouter.get("/library", asyncHandler(library));
+mediaRouter.get("/public/:id/stream", asyncHandler(streamPublicMedia));
+mediaRouter.get("/public/artwork/:id", asyncHandler(streamPublicArtwork));
 mediaRouter.post("/library/artists/discover", searchLimiter, asyncHandler(discoverArtists));
 mediaRouter.post("/library/artists", asyncHandler(createArtist));
 mediaRouter.get("/library/artists/:id", asyncHandler(artist));
@@ -35,4 +38,4 @@ mediaRouter.get("/jobs/:id", asyncHandler(getJob));
 mediaRouter.get("/artwork/:id", asyncHandler(streamArtwork));
 mediaRouter.get("/:id/stream", asyncHandler(streamMedia("stream")));
 mediaRouter.get("/:id/download", asyncHandler(streamMedia("download")));
-mediaRouter.delete("/:id", asyncHandler(deleteMedia));
+mediaRouter.delete("/:id", requireOwner, asyncHandler(deleteMedia));

--- a/src/server/routes/radio.routes.js
+++ b/src/server/routes/radio.routes.js
@@ -1,8 +1,12 @@
 import { Router } from "express";
-import { health, stations, stream } from "../controllers/radio.controller.js";
+import { createPersonalStation, deletePersonalStation, health, personalStations, stations, stream, updatePersonalStation } from "../controllers/radio.controller.js";
 import { asyncHandler } from "../utils/async-handler.js";
 
 export const radioRouter = Router();
 radioRouter.get("/health", asyncHandler(health));
 radioRouter.get("/stations", asyncHandler(stations));
 radioRouter.get("/stations/:id/:file", asyncHandler(stream));
+radioRouter.get("/my-stations", asyncHandler(personalStations));
+radioRouter.post("/my-stations", asyncHandler(createPersonalStation));
+radioRouter.patch("/my-stations/:id", asyncHandler(updatePersonalStation));
+radioRouter.delete("/my-stations/:id", asyncHandler(deletePersonalStation));

--- a/src/server/services/account.store.js
+++ b/src/server/services/account.store.js
@@ -43,6 +43,16 @@ db.exec(`
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL
   );
+  CREATE TABLE IF NOT EXISTS user_radio_stations (
+    id TEXT PRIMARY KEY CHECK(id LIKE 'urs_%'),
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    stream_url TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(user_id, stream_url)
+  );
+  CREATE INDEX IF NOT EXISTS user_radio_stations_user_idx ON user_radio_stations(user_id, updated_at DESC);
   CREATE INDEX IF NOT EXISTS user_sessions_user_idx ON user_sessions(user_id);
   CREATE INDEX IF NOT EXISTS user_sessions_expiry_idx ON user_sessions(expires_at);
 `);
@@ -169,3 +179,42 @@ export const consumeOAuthState = (provider, state) => {
   db.prepare("DELETE FROM oauth_states WHERE state_hash=?").run(hash);
   return true;
 };
+
+const publicRadioStation = (row) => row && ({
+  id: row.id, name: row.name, streamUrl: row.stream_url, personal: true,
+  createdAt: row.created_at, updatedAt: row.updated_at
+});
+
+export const listUserRadioStations = (userId) => db.prepare(
+  "SELECT * FROM user_radio_stations WHERE user_id=? ORDER BY updated_at DESC"
+).all(userId).map(publicRadioStation);
+
+export const createUserRadioStation = (userId, { name, streamUrl }) => {
+  if (Number(db.prepare("SELECT COUNT(*) count FROM user_radio_stations WHERE user_id=?").get(userId).count) >= 50) {
+    throw new TypeError("You can save up to 50 personal stations.");
+  }
+  const stamp = now(), stationId = id("urs");
+  try {
+    db.prepare("INSERT INTO user_radio_stations(id,user_id,name,stream_url,created_at,updated_at) VALUES (?,?,?,?,?,?)")
+      .run(stationId, userId, name, streamUrl, stamp, stamp);
+  } catch (error) {
+    if (String(error.message).includes("UNIQUE")) throw new TypeError("This stream is already saved.");
+    throw error;
+  }
+  return publicRadioStation(db.prepare("SELECT * FROM user_radio_stations WHERE id=? AND user_id=?").get(stationId, userId));
+};
+
+export const updateUserRadioStation = (userId, stationId, { name, streamUrl }) => {
+  try {
+    const result = db.prepare("UPDATE user_radio_stations SET name=?,stream_url=?,updated_at=? WHERE id=? AND user_id=?")
+      .run(name, streamUrl, now(), stationId, userId);
+    return result.changes ? publicRadioStation(db.prepare("SELECT * FROM user_radio_stations WHERE id=? AND user_id=?").get(stationId, userId)) : null;
+  } catch (error) {
+    if (String(error.message).includes("UNIQUE")) throw new TypeError("This stream is already saved.");
+    throw error;
+  }
+};
+
+export const deleteUserRadioStation = (userId, stationId) => db.prepare(
+  "DELETE FROM user_radio_stations WHERE id=? AND user_id=?"
+).run(stationId, userId).changes > 0;

--- a/src/server/services/app-secret.js
+++ b/src/server/services/app-secret.js
@@ -1,0 +1,38 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { env } from "../config/env.js";
+
+const secretFile = path.join(env.dataDir, "app-secret.key");
+
+const loadSecret = () => {
+  fs.mkdirSync(env.dataDir, { recursive: true });
+  try {
+    const value = fs.readFileSync(secretFile, "utf8").trim();
+    if (value.length >= 43) { fs.chmodSync(secretFile, 0o600); return value; }
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  const value = crypto.randomBytes(32).toString("base64url");
+  try { fs.writeFileSync(secretFile, `${value}\n`, { mode: 0o600, flag: "wx" }); }
+  catch (error) { if (error.code !== "EEXIST") throw error; return fs.readFileSync(secretFile, "utf8").trim(); }
+  return value;
+};
+
+const master = loadSecret();
+export const appKey = (purpose) => crypto.createHmac("sha256", master).update(String(purpose)).digest();
+
+export const sealSecret = (value, purpose) => {
+  const iv = crypto.randomBytes(12), cipher = crypto.createCipheriv("aes-256-gcm", appKey(purpose), iv);
+  const encrypted = Buffer.concat([cipher.update(String(value), "utf8"), cipher.final()]);
+  return `enc:v1:${[iv, cipher.getAuthTag(), encrypted].map((part) => part.toString("base64url")).join(".")}`;
+};
+
+export const openSecret = (value, purpose) => {
+  const encoded = String(value || "");
+  if (!encoded.startsWith("enc:v1:")) return encoded;
+  const [iv, tag, encrypted] = encoded.slice(7).split(".").map((part) => Buffer.from(part, "base64url"));
+  const decipher = crypto.createDecipheriv("aes-256-gcm", appKey(purpose), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+};

--- a/src/server/services/media-worker.service.js
+++ b/src/server/services/media-worker.service.js
@@ -49,6 +49,8 @@ export const getLyricsTranslationStatus = (trackId) => workerRequest({ pathname:
 export const getDueLyricsTranslations = (limit = 2) => workerRequest({ pathname: `/translation-jobs/due?limit=${encodeURIComponent(limit)}` });
 export const updateLyricsTranslationJob = (id, payload) => workerRequest({ method: "PATCH", pathname: `/translation-jobs/${encodeURIComponent(id)}`, body: payload });
 export const getLibrary = (userId) => workerRequest({ pathname: "/library", headers: userHeaders(userId) });
+export const getPublicLibrary = () => workerRequest({ pathname: "/public/library" });
+export const getPublicTrack = (id) => workerRequest({ pathname: `/public/library/tracks/${encodeURIComponent(id)}` });
 export const discoverLibraryArtists = (name) => workerRequest({ method: "POST", pathname: "/artists/discover", body: { name } });
 export const createLibraryArtist = (userId, payload) => workerRequest({ method: "POST", pathname: "/artists", body: payload, headers: userHeaders(userId) });
 export const getLibraryArtist = (userId, id) => workerRequest({ pathname: `/artists/${encodeURIComponent(id)}`, headers: userHeaders(userId) });
@@ -74,3 +76,8 @@ export const mediaStream = (id, kind, range) => workerRequest({
   stream: true
 });
 export const artworkStream = (id) => workerRequest({ pathname: `/artwork/${encodeURIComponent(id)}`, stream: true });
+export const publicMediaStream = (id, range) => workerRequest({
+  pathname: `/public/media/${encodeURIComponent(id)}/stream`,
+  headers: range ? { Range: range } : {}, stream: true
+});
+export const publicArtworkStream = (id) => workerRequest({ pathname: `/public/artwork/${encodeURIComponent(id)}`, stream: true });

--- a/src/server/services/media-worker.service.js
+++ b/src/server/services/media-worker.service.js
@@ -7,7 +7,7 @@ const workerUrl = new URL(env.mediaWorkerUrl);
 const transport = workerUrl.protocol === "https:" ? https : http;
 const userHeaders = (userId) => userId ? { "X-Translator-User-Id": userId } : {};
 
-const workerRequest = ({ method = "GET", pathname, body, headers = {}, stream = false }) =>
+const workerAttempt = ({ method = "GET", pathname, body, headers = {}, stream = false }) =>
   new Promise((resolve, reject) => {
     const payload = body === undefined ? null : Buffer.from(JSON.stringify(body));
     const request = transport.request(new URL(pathname, workerUrl), {
@@ -35,6 +35,15 @@ const workerRequest = ({ method = "GET", pathname, body, headers = {}, stream = 
     if (payload) request.write(payload);
     request.end();
   });
+
+const workerRequest = async (options) => {
+  try { return await workerAttempt(options); }
+  catch (error) {
+    if ((options.method || "GET") !== "GET" || error.status !== 503) throw error;
+    await new Promise((resolve) => setTimeout(resolve, 650));
+    return workerAttempt(options);
+  }
+};
 
 export const mediaHealth = () => workerRequest({ pathname: "/health" });
 export const createMediaJob = (userId, url) => workerRequest({ method: "POST", pathname: "/jobs", body: { url }, headers: userHeaders(userId) });

--- a/src/server/services/settings.store.js
+++ b/src/server/services/settings.store.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { env } from "../config/env.js";
 import { providerCatalog, providerMap, publicModels } from "../config/providers.js";
 import { HttpError } from "../utils/http-error.js";
+import { openSecret, sealSecret } from "./app-secret.js";
 
 const settingsFile = path.join(env.dataDir, "settings.json");
 
@@ -19,7 +20,8 @@ let store = load();
 const persist = () => {
   try {
     fs.mkdirSync(env.dataDir, { recursive: true });
-    fs.writeFileSync(settingsFile, JSON.stringify(store, null, 2));
+    fs.writeFileSync(settingsFile, JSON.stringify(store, null, 2), { mode: 0o600 });
+    fs.chmodSync(settingsFile, 0o600);
   } catch {}
 };
 
@@ -38,7 +40,7 @@ const requireProvider = (id) => {
 const resolveKey = (id) => {
   const provider = providerMap[id];
   if (!provider) return "";
-  const saved = String(storedProvider(id).apiKey || "").trim();
+  const saved = String(openSecret(storedProvider(id).apiKey || "", `provider:${id}`) || "").trim();
   return saved || envKey(provider);
 };
 
@@ -106,12 +108,21 @@ export const setProviderKey = (id, apiKey) => {
   store.providers[id] = store.providers[id] || {};
   const clean = String(apiKey || "").trim();
   if (clean) {
-    store.providers[id].apiKey = clean;
+    store.providers[id].apiKey = sealSecret(clean, `provider:${id}`);
   } else {
     delete store.providers[id].apiKey;
   }
   persist();
 };
+
+// Migrate legacy plaintext provider keys in place without changing their runtime value.
+let migrated = false;
+for (const [id, value] of Object.entries(store.providers || {})) {
+  if (value?.apiKey && !String(value.apiKey).startsWith("enc:v1:")) {
+    value.apiKey = sealSecret(value.apiKey, `provider:${id}`); migrated = true;
+  }
+}
+if (migrated) persist(); else if (fs.existsSync(settingsFile)) { try { fs.chmodSync(settingsFile, 0o600); } catch {} }
 
 export const setProviderModel = (id, model) => {
   const provider = requireProvider(id);

--- a/src/server/services/spotify-account.service.js
+++ b/src/server/services/spotify-account.service.js
@@ -2,11 +2,13 @@ import crypto from "node:crypto";
 import { env } from "../config/env.js";
 import { HttpError } from "../utils/http-error.js";
 import { getSpotifyAccount, importSpotifyPlaylistCache, saveSpotifyAccount } from "./media-worker.service.js";
+import { appKey } from "./app-secret.js";
 
 const authorizeUrl = "https://accounts.spotify.com/authorize";
 const tokenUrl = "https://accounts.spotify.com/api/token";
 const scopes = "playlist-read-private";
-const key = () => crypto.createHash("sha256").update(`${env.ownerPassword}:${env.spotifyClientSecret}`).digest();
+const legacyKey = () => crypto.createHash("sha256").update(`${env.ownerPassword}:${env.spotifyClientSecret}`).digest();
+const key = () => appKey("spotify-tokens");
 
 const seal = (value) => {
   const iv = crypto.randomBytes(12);
@@ -16,23 +18,30 @@ const seal = (value) => {
 };
 
 const open = (value) => {
-  const [iv, tag, encrypted] = String(value || "").split(".").map((part) => Buffer.from(part, "base64url"));
-  const decipher = crypto.createDecipheriv("aes-256-gcm", key(), iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+  const parts = String(value || "").split(".").map((part) => Buffer.from(part, "base64url"));
+  for (const candidate of [key(), legacyKey()]) {
+    try {
+      const decipher = crypto.createDecipheriv("aes-256-gcm", candidate, parts[0]);
+      decipher.setAuthTag(parts[1]);
+      return Buffer.concat([decipher.update(parts[2]), decipher.final()]).toString("utf8");
+    } catch { /* Existing tokens may still use the legacy deployment key. */ }
+  }
+  throw new HttpError(401, "Reconnect Spotify to refresh your secure session.");
 };
 
 const signedState = (userId) => {
   const payload = Buffer.from(JSON.stringify({ exp: Date.now() + 10 * 60 * 1000, nonce: crypto.randomUUID(), userId })).toString("base64url");
-  const signature = crypto.createHmac("sha256", env.ownerPassword).update(payload).digest("base64url");
+  const signature = crypto.createHmac("sha256", appKey("spotify-state")).update(payload).digest("base64url");
   return `${payload}.${signature}`;
 };
 
 const verifyState = (state) => {
   const [payload, signature] = String(state || "").split(".");
   if (!payload || !signature) return false;
-  const expected = crypto.createHmac("sha256", env.ownerPassword).update(payload).digest("base64url");
-  if (signature.length !== expected.length || !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return false;
+  const expected = crypto.createHmac("sha256", appKey("spotify-state")).update(payload).digest("base64url");
+  const legacy = crypto.createHmac("sha256", env.ownerPassword).update(payload).digest("base64url");
+  const matches = (candidate) => signature.length === candidate.length && crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(candidate));
+  if (!matches(expected) && !matches(legacy)) return false;
   try {
     const decoded = JSON.parse(Buffer.from(payload, "base64url").toString());
     return decoded.exp > Date.now() ? decoded : null;

--- a/src/server/services/user-radio.service.js
+++ b/src/server/services/user-radio.service.js
@@ -1,0 +1,27 @@
+import net from "node:net";
+
+const privateIpv4 = (host) => {
+  const parts = host.split(".").map(Number);
+  return parts[0] === 10 || parts[0] === 127 || parts[0] === 0 ||
+    (parts[0] === 169 && parts[1] === 254) || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168);
+};
+
+export const normalizeUserStation = (payload) => {
+  const name = String(payload?.name || "").trim().replace(/\s+/g, " ").slice(0, 80);
+  if (!name) throw new TypeError("Enter a station name.");
+  let url;
+  try { url = new URL(String(payload?.streamUrl || "").trim()); }
+  catch { throw new TypeError("Enter a valid stream URL."); }
+  if (url.protocol !== "https:" || url.username || url.password || url.href.length > 2048) {
+    throw new TypeError("Use a secure HTTPS stream URL.");
+  }
+  const host = url.hostname.toLowerCase();
+  const ipKind = net.isIP(host);
+  if (host === "localhost" || host.endsWith(".local") || (ipKind === 4 && privateIpv4(host)) ||
+      (ipKind === 6 && (host === "::1" || host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:")))) {
+    throw new TypeError("Local network stream URLs are not allowed.");
+  }
+  url.hash = "";
+  return { name, streamUrl: url.href };
+};

--- a/test/auth-http.test.js
+++ b/test/auth-http.test.js
@@ -78,3 +78,27 @@ test("a repeated Google callback returns an authenticated browser to the app", a
   assert.equal(callback.status, 302);
   assert.equal(callback.headers.get("location"), "/?auth=google_success");
 });
+
+test("personal radio stations require a session and stay editable for their owner", async () => {
+  assert.equal((await fetch(`${base}/api/radio/my-stations`)).status, 401);
+  const registration = await fetch(`${base}/api/auth/register`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "radio-owner@example.com", password: "correct-horse", displayName: "Radio Owner" })
+  });
+  const cookie = registration.headers.get("set-cookie").split(";", 1)[0];
+  const createdResponse = await fetch(`${base}/api/radio/my-stations`, {
+    method: "POST", headers: { Cookie: cookie, "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "My station", streamUrl: "https://radio.example.com/live.mp3" })
+  });
+  assert.equal(createdResponse.status, 201);
+  const created = await createdResponse.json();
+  assert.match(created.id, /^urs_/);
+  const updatedResponse = await fetch(`${base}/api/radio/my-stations/${created.id}`, {
+    method: "PATCH", headers: { Cookie: cookie, "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Night mix", streamUrl: "https://radio.example.com/live.mp3" })
+  });
+  assert.equal((await updatedResponse.json()).name, "Night mix");
+  const listed = await fetch(`${base}/api/radio/my-stations`, { headers: { Cookie: cookie } });
+  assert.equal((await listed.json()).stations.length, 1);
+  assert.equal((await fetch(`${base}/api/radio/my-stations/${created.id}`, { method: "DELETE", headers: { Cookie: cookie } })).status, 200);
+});

--- a/test/media-database.test.js
+++ b/test/media-database.test.js
@@ -85,3 +85,26 @@ test("repositories cache entities with independent prefixed ids and relative pat
   assert.equal(repo.playlists.findById(playlist.id), null);
   db.close();
 });
+
+test("the guest catalog only exposes fully verified open-license songs", () => {
+  const db = openDatabase({ filename: ":memory:" });
+  const repo = createRepositories(db);
+  const addTrack = (externalId, license) => {
+    const track = repo.tracks.upsert({ source: "jamendo", externalId, title: externalId, artist: "Open Artist" });
+    repo.lyrics.upsert({ trackId: track.id, source: "lrclib", externalId, contentHash: `lyrics-${externalId}`, relativePath: `lyrics/${externalId}/original.json` });
+    const media = repo.media.upsert({ trackId: track.id, provider: "jamendo", providerMediaId: externalId, relativePath: `media/${externalId}/audio.mp3` });
+    repo.licenses.upsert({ trackId: track.id, licenseCode: license.code, licenseUrl: "https://creativecommons.org/licenses/by/4.0/",
+      rightsHolder: "Open Artist", attributionText: `${externalId} by Open Artist`, evidenceUrl: "https://example.com/evidence",
+      evidenceHash: `evidence-${externalId}`, evidenceRelativePath: `licenses/${externalId}/evidence.json`,
+      coversRecording: true, coversComposition: true, coversLyrics: license.coversLyrics });
+    return { track, media };
+  };
+  const publicSong = addTrack("public-song", { code: "CC BY 4.0", coversLyrics: true });
+  const incomplete = addTrack("missing-lyrics-rights", { code: "CC BY 4.0", coversLyrics: false });
+  const closed = addTrack("closed-song", { code: "All rights reserved", coversLyrics: true });
+  assert.deepEqual(repo.library.publicCatalog().map((row) => row.id), [publicSong.track.id]);
+  assert.ok(repo.media.findPublicById(publicSong.media.id));
+  assert.equal(repo.media.findPublicById(incomplete.media.id), null);
+  assert.equal(repo.media.findPublicById(closed.media.id), null);
+  db.close();
+});


### PR DESCRIPTION
## Summary
- Adds guest open-music access and personal HLS radio stations (save/list/update/delete per user)
- Introduces encrypted app-secret service for sealing sensitive account data
- Adds scheduled data backups (script + systemd service/timer) with retention
- Hardens systemd unit files for media-worker, radio-worker, translator-web, translator
- Retries media reads during worker startup to avoid transient failures
- Adds tests for auth HTTP flow and media database

## Commits
- feat: add guest open-music access and personal radio
- chore: harden secrets services and local backups
- feat: support personal HLS radio streams
- fix: retry media reads during worker startup
- ops: restore translator service controls